### PR TITLE
最低限エラーハンドリング（Laravelエラーが出ないようにする）

### DIFF
--- a/app/Http/Controllers/GoogleSearchController.php
+++ b/app/Http/Controllers/GoogleSearchController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\SearchRequest;
 use Illuminate\Support\Facades\Http;
 
 class GoogleSearchController extends Controller
@@ -10,14 +10,19 @@ class GoogleSearchController extends Controller
     /**
      * テキスト検索を行う
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  App\Http\Requests\SearchRequest  $request
      * @return \Illuminate\View\View
      */
-    public function text(Request $request)
+    public function text(SearchRequest $request)
     {
         $apiKey = config('googleSearch.api_key');
         $searchEngineId = config('googleSearch.engine_id');
-        $query = $request->query('query');
+        $query = mb_substr(
+            $request->input('query'),
+            0,
+            config('googleSearch.max_length_in_google_search'),
+            'UTF-8'
+        );
         $language = $request->query('language', trans('search_options.lang_ja'));
 
         // MEMO: クエリパラメータに関しては以下を参照

--- a/app/Http/Requests/SearchRequest.php
+++ b/app/Http/Requests/SearchRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'query' => 'required',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'query.required' => '検索したい文字列を入力してください',
+        ];
+    }
+}

--- a/config/googleSearch.php
+++ b/config/googleSearch.php
@@ -1,7 +1,10 @@
 <?php
 
 return [
+    // Google検索は先頭32文字まで有効（らしい）
+    'max_length_in_google_search' => 32,
     'end_point' => "https://www.googleapis.com/customsearch/v1",
+    // @see: README.md
     'api_key' => env('API_KEY'),
     'engine_id' => env('ENGINE_ID'),
 ];

--- a/resources/views/googleSearch.blade.php
+++ b/resources/views/googleSearch.blade.php
@@ -5,6 +5,7 @@
     <title>GoogleSearch</title>
 </head>
 <body>
+    <!-- 検索フォーム -->
     <div>
         <form action="{{ route('text_search') }}" method="GET">
             @csrf
@@ -13,20 +14,36 @@
                     <option value="{{ $value }}">{{ $label }}</option>
                 @endforeach
             </select>
-            <input type="text" name="query" placeholder="キーワードを入力してください">
+            <input
+                type="text"
+                name="query"
+                placeholder="キーワードを入力してください"
+                maxlength={{config('googleSearch.max_length_in_google_search')}}
+            >
             <button type="submit">検索</button>
         </form>
     </div>
-    @if(isset($results))
-        <h2>- 「{{ $results['query'] }}」の検索結果 -</h2>
+    <!-- 検索結果表示 -->
+    @if($errors->any())
         <ul>
-            @foreach($results['items'] as $item)
-                <li>
-                    <a href="{{ $item['link'] }}">{{ $item['title'] }}</a>
-                    <p>{{ $item['snippet'] }}</p>
-                </li>
+            @foreach($errors->all() as $error)
+                <li>{{ $error }}</li>
             @endforeach
         </ul>
+    @elseif(isset($results))
+        <h2>- 「{{ $results['query'] }}」の検索結果 -</h2>
+        @if(empty($results['items']))
+            <p>検索結果がありません</p>
+        @else
+            <ul>
+                @foreach($results['items'] as $item)
+                    <li>
+                        <a href="{{ $item['link'] }}">{{ $item['title'] }}</a>
+                        <p>{{ $item['snippet'] }}</p>
+                    </li>
+                @endforeach
+            </ul>
+        @endif
     @endif
 </body>
 </html>


### PR DESCRIPTION
## 概要
以下のエラーハンドリングを実装
- 検索窓が空の場合「検索したい文字列を入力してください」
- 検索結果がないの場合「検索結果がありません」
- （Google検索は先頭32文字まで有効らしいので検索はmax32文字可能にした）
