### PR TITLE
次の10件を表示する機能を追加

### DIFF
--- a/app/Http/Controllers/GoogleSearchController.php
+++ b/app/Http/Controllers/GoogleSearchController.php
@@ -24,6 +24,7 @@ class GoogleSearchController extends Controller
             'UTF-8'
         );
         $language = $request->query('language', trans('search_options.lang_ja'));
+        $start = $request->input('start', 1);
 
         // MEMO: クエリパラメータに関しては以下を参照
         // @see: https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list?hl=ja
@@ -32,10 +33,10 @@ class GoogleSearchController extends Controller
             'cx' => $searchEngineId,
             'q' => $query,
             'lr' => $language,
+            'start' => $start,
         ]);
 
         $results = $response->json();
-        $results['query'] = $query;
         // snippetキーが存在しない結果を除外
         if (isset($results['items'])) {
             $filteredItems = array_filter($results['items'], function ($item) {
@@ -43,6 +44,7 @@ class GoogleSearchController extends Controller
             });
             $results['items'] = array_values($filteredItems);
         }
-        return view('googleSearch', compact('results'));
+        $searchOptions = trans('search_options');
+        return view('googleSearch', compact('results', 'query', 'start', 'language', 'searchOptions'));
     }
 }

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -91,3 +91,31 @@ select {
     margin: 10px;
     color: #333;
 }
+
+/* ページングリンクのスタイル */
+.pagination {
+    text-align: center;
+    margin: 20px;
+    font-size: 20px;
+}
+
+.pagination a {
+    display: inline-block;
+    padding: 5px 10px;
+    margin: 5px;
+    background-color: #007bff;
+    color: #fff;
+    border-radius: 5px;
+    text-decoration: none;
+    transition: background-color 0.3s;
+}
+
+.pagination a:hover {
+    background-color: #0056b3;
+}
+
+/* 現在のページリンクのスタイル */
+.pagination .current {
+    background-color: #0056b3;
+    font-weight: bold;
+}

--- a/resources/views/googleSearch.blade.php
+++ b/resources/views/googleSearch.blade.php
@@ -12,13 +12,16 @@
             @csrf
             <select name="language" id="language">
                 @foreach(trans('search_options') as $value => $label)
-                    <option value="{{ $value }}">{{ $label }}</option>
+                    <option value="{{ $value }}" @if($language === $value) selected @endif>
+                        {{ $label }}
+                    </option>
                 @endforeach
             </select>
             <input
                 type="text"
                 name="query"
                 placeholder="キーワードを入力してください"
+                value="{{ $query ?? '' }}"
                 maxlength={{config('googleSearch.max_length_in_google_search')}}
             >
             <button type="submit">検索</button>
@@ -32,15 +35,25 @@
             @endforeach
         </ul>
     @elseif(isset($results))
-        <h2>- 「{{ $results['query'] }}」の検索結果 -</h2>
+        <h2>- 「{{ $query }}」の検索結果 -</h2>
         @if(empty($results['items']))
             <p>検索結果がありません</p>
         @else
+            <!-- ページ番号と全ページ数を表示 -->
+            <div class="pagination-info">
+                {{
+                    ceil($results['queries']['request'][0]['startIndex'] / $results['queries']['request'][0]['count']
+                )}}ページ目/
+                {{
+                    ceil($results['searchInformation']['totalResults'] / $results['queries']['request'][0]['count']
+                )}}ページ中
+            </div>
             <ul class="result-list">
                 @foreach($results['items'] as $item)
                     <a href="{{ $item['link'] }}" class="result-link">
                         <li class="result-item">
-                            <h3>{{ $item['title'] }}</h3><p>{{ $item['formattedUrl'] }}</p>
+                            <h3>{{ $item['title'] }}</h3>
+                            <p>{{ $item['formattedUrl'] }}</p>
                             <p class="result-snippet">
                                 {{ $item['snippet'] }}
                             </p>
@@ -48,6 +61,17 @@
                     </a>
                 @endforeach
             </ul>
+            <!-- ページングリンクの生成 -->
+            @if(isset($results['queries']['nextPage']))
+                <div class="pagination">
+                    <a href="{{route('text_search',[
+                        'query' => $query,
+                        'start' => $results['queries']['nextPage'][0]['startIndex'], 'language' => $language]
+                    )}}" class="pagination">
+                        Next Page
+                    </a>
+                </div>
+            @endif
         @endif
     @endif
 </body>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,8 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('/', function () {
-    return view('googleSearch');
+    $language = trans('search_options.lang_ja');
+    return view('googleSearch', compact('language'));
 });
 Route::get(
     '/google_search',


### PR DESCRIPTION
## 概要
- #10 
    - 次ページ機能を実装
    - 現在のページ数、総ページ数も実装
- #6 
    - 検索言語選択のプルダウンが、検索後、検索を行った言語のままになるようにした
    - （次ページ機能実装の際、クエリに検索言語（language）を含める必要が出てきたため、ついでに実装）